### PR TITLE
Add function to check for dev instance

### DIFF
--- a/src/apollo/index.ts
+++ b/src/apollo/index.ts
@@ -8,6 +8,7 @@ import { applyMiddleware } from "graphql-middleware";
 import { GraphQLSchema } from "graphql";
 import { FastifyInstance } from "fastify";
 import { getAuthData } from "../utils";
+import { envHandler } from "../utils/envHandler";
 
 export const createApolloServer = (
     midlewares: [object],
@@ -35,9 +36,9 @@ export const createApolloServer = (
                     };
                 }
             },
-            process.env.NODE_ENV === "production"
-                ? ApolloServerPluginLandingPageDisabled() // eslint-disable-line new-cap
-                : ApolloServerPluginLandingPageLocalDefault({ embed: true }) // eslint-disable-line new-cap
+            envHandler.isDevelopmentInstance()
+                ? ApolloServerPluginLandingPageLocalDefault({ embed: true }) // eslint-disable-line new-cap
+                : ApolloServerPluginLandingPageDisabled() // eslint-disable-line new-cap
         ]
     });
 };

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -1,9 +1,9 @@
-import { envReader } from "../utils/envReader";
+import { envHandler } from "../utils/envHandler";
 
 export default {
-    DB_NAME: envReader.get("DB_NAME"),
-    DB_USER: envReader.get("DB_USER"),
-    DB_PASS: envReader.get("DB_PASS"),
-    DB_HOST: envReader.get("DB_HOST"),
-    DB_PORT: parseInt(envReader.get("DB_PORT", "3306"))
+    DB_NAME: envHandler.get("DB_NAME"),
+    DB_USER: envHandler.get("DB_USER"),
+    DB_PASS: envHandler.get("DB_PASS"),
+    DB_HOST: envHandler.get("DB_HOST"),
+    DB_PORT: parseInt(envHandler.get("DB_PORT", "3306"))
 };

--- a/src/guards/index.ts
+++ b/src/guards/index.ts
@@ -1,4 +1,5 @@
 import { shield } from "graphql-shield";
+import { envHandler } from "../utils/envHandler";
 
 import { isAuthorized } from "./rules/index";
 
@@ -14,7 +15,6 @@ export const permissions = shield(
         }
     },
     {
-        allowExternalErrors:
-            !process.env.NODE_ENV || process.env.NODE_ENV == "development"
+        allowExternalErrors: envHandler.isDevelopmentInstance()
     }
 );

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { typeDefs, resolvers } from "./graphql/index";
 import { permissions } from "./guards/index";
 import { createApolloServer } from "./apollo/index";
 import { databaseConnection } from "./db/index";
+import { envHandler } from "./utils/envHandler";
 
 export const startApolloServer = async () => {
     const app = fastify();
@@ -17,7 +18,7 @@ export const startApolloServer = async () => {
     const server = createApolloServer([permissions], app, schema);
     await server.start();
 
-    if ((process.env.NODE_ENV || "development") === "development") {
+    if (envHandler.isDevelopmentInstance()) {
         await databaseConnection.sync({ alter: true });
     } else {
         await databaseConnection.sync();

--- a/src/utils/auth/signToken.ts
+++ b/src/utils/auth/signToken.ts
@@ -1,7 +1,7 @@
 import jwt from "jsonwebtoken";
-import { envReader } from "../envReader";
+import { envHandler } from "../envHandler";
 import { CustomJwtPayload } from "./model";
 
 export const signToken = (data: CustomJwtPayload) => {
-    return jwt.sign(data, envReader.get("JWT_SECRET"));
+    return jwt.sign(data, envHandler.get("JWT_SECRET"));
 };

--- a/src/utils/auth/verifyToken.ts
+++ b/src/utils/auth/verifyToken.ts
@@ -1,7 +1,7 @@
 import jwt from "jsonwebtoken";
-import { envReader } from "../envReader";
+import { envHandler } from "../envHandler";
 import { CustomJwtPayload } from "./model";
 
 export const verifyToken = (token: string) => {
-    return <CustomJwtPayload>jwt.verify(token, envReader.get("JWT_SECRET"));
+    return <CustomJwtPayload>jwt.verify(token, envHandler.get("JWT_SECRET"));
 };

--- a/src/utils/envHandler.ts
+++ b/src/utils/envHandler.ts
@@ -1,10 +1,9 @@
 /**
- * A helper class to read environment variables and return a default
- * value if not set. If no default value is given, an error is thrown.
+ * A helper class to make handling with the environment easier.
  *
  * @class
  */
-class EnvReader {
+class EnvHandler {
     /**
      * Will return the given environment variable. If not set, default value will be returned.
      * If no default value is given, an error is thrown.
@@ -21,6 +20,15 @@ class EnvReader {
             "Please define a value for environment variable " + envVar
         );
     }
+
+    /**
+     * Will return true if we are currently executed in an development instance.
+     *
+     * @return {boolean} True if we are executed in an development instance.
+     */
+    isDevelopmentInstance(): boolean {
+        return this.get("NODE_ENV", "development") == "development";
+    }
 }
 
-export const envReader = new EnvReader();
+export const envHandler = new EnvHandler();


### PR DESCRIPTION
This makes future adaptions easier and ensures a consistent handling of dev and non-dev instances.
For this, renamed EnvReader class to EnvHandler.