### PR TITLE
Add initial support for shopping lists

### DIFF
--- a/src/db/model/ListItem.ts
+++ b/src/db/model/ListItem.ts
@@ -3,29 +3,30 @@ import {
     Model,
     InferAttributes,
     InferCreationAttributes,
-    CreationOptional,
-    NonAttribute
+    ForeignKey,
+    CreationOptional
 } from "sequelize";
 
 import { databaseConnection } from "../index";
-import { Device } from "./Device";
 import { ShoppingList } from "./Shoppinglist";
 
 /**
- * Describes a user
+ * Describes an item of a shopping list
  */
-class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
+class ListItem extends Model<
+    InferAttributes<ListItem>,
+    InferCreationAttributes<ListItem>
+> {
     // id can be undefined during creation when using `autoIncrement`
     declare id: CreationOptional<number>;
 
-    declare username: string;
-    declare password: string;
+    declare value: string;
+    declare bought: CreationOptional<boolean>;
 
-    declare devices: NonAttribute<Device[]>;
-    declare shoppingLists: NonAttribute<ShoppingList[]>;
+    declare listId: ForeignKey<number>;
 }
 
-User.init(
+ListItem.init(
     {
         id: {
             type: DataTypes.INTEGER,
@@ -33,25 +34,24 @@ User.init(
             autoIncrement: true,
             allowNull: false
         },
-        username: {
+        value: {
             type: DataTypes.STRING,
-            unique: true,
+            defaultValue: "",
             allowNull: false
         },
-        password: {
-            type: DataTypes.STRING,
+        bought: {
+            type: DataTypes.BOOLEAN,
+            defaultValue: false,
             allowNull: false
         }
     },
     {
         sequelize: databaseConnection,
         timestamps: false,
-        modelName: "user"
+        modelName: "listItem"
     }
 );
 
-User.hasMany(Device);
-User.hasMany(ShoppingList, { foreignKey: "owner" });
-ShoppingList.belongsToMany(User, { through: "sharedWith" });
+ListItem.belongsTo(ShoppingList, { as: "listId" });
 
-export { User };
+export { ListItem };

--- a/src/db/model/Shoppinglist.ts
+++ b/src/db/model/Shoppinglist.ts
@@ -1,0 +1,38 @@
+import {
+    DataTypes,
+    Model,
+    InferAttributes,
+    InferCreationAttributes,
+    ForeignKey
+} from "sequelize";
+
+import { databaseConnection } from "../index";
+
+/**
+ * Describes a shopping list
+ */
+class ShoppingList extends Model<
+    InferAttributes<ShoppingList>,
+    InferCreationAttributes<ShoppingList>
+> {
+    declare name: string;
+
+    declare owner: ForeignKey<number>;
+}
+
+ShoppingList.init(
+    {
+        name: {
+            type: DataTypes.STRING,
+            defaultValue: "",
+            allowNull: false
+        }
+    },
+    {
+        sequelize: databaseConnection,
+        timestamps: false,
+        modelName: "list"
+    }
+);
+
+export { ShoppingList };

--- a/src/graphql/resolvers/Mutations/index.ts
+++ b/src/graphql/resolvers/Mutations/index.ts
@@ -1,1 +1,3 @@
+export * from "./shoppingList/index";
+export * from "./shoppingListItem/index";
 export * from "./user/index";

--- a/src/graphql/resolvers/Mutations/shoppingList/addShoppingList.ts
+++ b/src/graphql/resolvers/Mutations/shoppingList/addShoppingList.ts
@@ -1,0 +1,17 @@
+import { ShoppingList } from "../../../../db/model/Shoppinglist";
+import { DidYouGetLoginData } from "../../../../utils/auth/model";
+
+export const addShoppingList = async (
+    _parent: object,
+    args: { input: { name: string } },
+    context: { auth: DidYouGetLoginData }
+) => {
+    const { name } = args.input;
+
+    const result = await ShoppingList.create({
+        name: name,
+        owner: context.auth.userid
+    });
+
+    return result;
+};

--- a/src/graphql/resolvers/Mutations/shoppingList/index.ts
+++ b/src/graphql/resolvers/Mutations/shoppingList/index.ts
@@ -1,0 +1,1 @@
+export * from "./addShoppingList";

--- a/src/graphql/resolvers/Mutations/shoppingListItem/addShoppingListItem.ts
+++ b/src/graphql/resolvers/Mutations/shoppingListItem/addShoppingListItem.ts
@@ -1,0 +1,16 @@
+import { ListItem } from "../../../../db/model/ListItem";
+
+export const addShoppingListItem = async (
+    _parent: object,
+    args: { input: { shoppingListId: number; value: string } }
+) => {
+    const { shoppingListId, value } = args.input;
+
+    // TODO: Check if current user can access the shopping list (owner or shared)
+    const result = await ListItem.create({
+        listId: shoppingListId,
+        value: value
+    });
+
+    return result;
+};

--- a/src/graphql/resolvers/Mutations/shoppingListItem/index.ts
+++ b/src/graphql/resolvers/Mutations/shoppingListItem/index.ts
@@ -1,0 +1,1 @@
+export * from "./addShoppingListItem";

--- a/src/graphql/typeDefs/Mutations/ShoppingList.gql
+++ b/src/graphql/typeDefs/Mutations/ShoppingList.gql
@@ -1,0 +1,7 @@
+input addShoppingListInput {
+    name: String!
+}
+
+type Mutation {
+    addShoppingList(input: addShoppingListInput): ShoppingList
+}

--- a/src/graphql/typeDefs/Mutations/ShoppingListItem.gql
+++ b/src/graphql/typeDefs/Mutations/ShoppingListItem.gql
@@ -1,0 +1,8 @@
+input addShoppingListItemInput {
+    shoppingListId: ID!
+    value: String!
+}
+
+type Mutation {
+    addShoppingListItem(input: addShoppingListItemInput): ShoppingListItem
+}

--- a/src/graphql/typeDefs/model/ShoppingList.gql
+++ b/src/graphql/typeDefs/model/ShoppingList.gql
@@ -1,0 +1,6 @@
+type ShoppingList {
+    id: ID,
+    owner: ID,
+    name: String,
+    items: [ShoppingListItem]
+}

--- a/src/graphql/typeDefs/model/ShoppingListItem.gql
+++ b/src/graphql/typeDefs/model/ShoppingListItem.gql
@@ -1,0 +1,4 @@
+type ShoppingListItem {
+    id: ID,
+    value: String
+}

--- a/src/guards/index.ts
+++ b/src/guards/index.ts
@@ -10,6 +10,11 @@ export const permissions = shield(
             getUser: isAuthorized
         },
         Mutation: {
+            // ShoppingList
+            addShoppingList: isAuthorized,
+            // ShoppingListItem
+            addShoppingListItem: isAuthorized,
+            // User
             updateUser: isAuthorized,
             logout: isAuthorized
         }


### PR DESCRIPTION
Currently we can add shopping lists and items to existing lists. No update/deletion/renaming whatsoever.
Also no proper access checks so that you can only add items to the lists where you are owner or which are shared with you.