### PR TITLE
Return "success: false" if there are errors on user creation

### DIFF
--- a/src/graphql/resolvers/Mutations/user/register.ts
+++ b/src/graphql/resolvers/Mutations/user/register.ts
@@ -9,12 +9,17 @@ export const register = async (
 
     const hashedPassword = await hashPassword(password);
 
-    await User.create({
-        username: username,
-        password: hashedPassword
-    });
+    let success = true;
+    try {
+        await User.create({
+            username: username,
+            password: hashedPassword
+        });
+    } catch {
+        success = false;
+    }
 
     return {
-        success: true
+        success: success
     };
 };

--- a/tests/server.user.test.ts
+++ b/tests/server.user.test.ts
@@ -78,6 +78,20 @@ describe("user related graphql tests", () => {
         expect(response.body.data?.register.success).toBeTruthy();
     });
 
+    it("should be not possible to register the same user again", async () => {
+        const response = await runGraphQlQuery({
+            query: `mutation registerUser($userData: userInput!) {
+                register(input: $userData) {
+                    success
+                }
+            }`,
+            variables: { userData: userData }
+        });
+
+        expect(response.body.errors).toBeUndefined();
+        expect(response.body.data?.register.success).toBe(false);
+    });
+
     it("should login successfully", async () => {
         await login();
         expect(authToken).toBeTruthy();


### PR DESCRIPTION
... instead of throwing an "Unauthorized" error in prod. Also added testcase to verify the new behavior.