### PR TITLE
Restructure graphql queries for future extension

### DIFF
--- a/src/graphql/resolvers/Queries/getUser.ts
+++ b/src/graphql/resolvers/Queries/getUser.ts
@@ -1,7 +1,0 @@
-import { Identifier } from "sequelize";
-import { User } from "../../../db/model/index";
-
-export const getUser = async (_parent: object, args: { id: Identifier }) => {
-    const result = await User.findByPk(args.id);
-    return result;
-};

--- a/src/graphql/resolvers/Queries/getUsers.ts
+++ b/src/graphql/resolvers/Queries/getUsers.ts
@@ -1,6 +1,0 @@
-import { User } from "../../../db/model/index";
-
-export const getUsers = async () => {
-    const result = await User.findAll();
-    return result;
-};

--- a/src/graphql/resolvers/Queries/index.ts
+++ b/src/graphql/resolvers/Queries/index.ts
@@ -1,2 +1,1 @@
-export * from "./getUser";
-export * from "./getUsers";
+export * from "./user/index";

--- a/src/graphql/resolvers/Queries/user/index.ts
+++ b/src/graphql/resolvers/Queries/user/index.ts
@@ -1,0 +1,2 @@
+export * from "./user";
+export * from "./users";

--- a/src/graphql/resolvers/Queries/user/user.ts
+++ b/src/graphql/resolvers/Queries/user/user.ts
@@ -1,0 +1,16 @@
+import { Identifier } from "sequelize";
+import { User } from "../../../../db/model/User";
+import { DidYouGetLoginData } from "../../../../utils/auth/model";
+
+export const user = async (
+    _parent: object,
+    args: { id: Identifier | undefined },
+    context: { auth: DidYouGetLoginData }
+) => {
+    let id = args.id;
+    if (!id) {
+        id = context.auth.userid;
+    }
+    const result = await User.findByPk(id);
+    return result;
+};

--- a/src/graphql/resolvers/Queries/user/users.ts
+++ b/src/graphql/resolvers/Queries/user/users.ts
@@ -1,0 +1,6 @@
+import { User } from "../../../../db/model/User";
+
+export const users = async () => {
+    const result = await User.findAll();
+    return result;
+};

--- a/src/graphql/typeDefs/Queries/User.gql
+++ b/src/graphql/typeDefs/Queries/User.gql
@@ -1,0 +1,4 @@
+type Query {
+    user(id: ID): User
+    users: [User]
+}

--- a/src/graphql/typeDefs/Queries/getUser.gql
+++ b/src/graphql/typeDefs/Queries/getUser.gql
@@ -1,3 +1,0 @@
-type Query {
-    getUser(id: ID!): User
-}

--- a/src/graphql/typeDefs/Queries/getUsers.gql
+++ b/src/graphql/typeDefs/Queries/getUsers.gql
@@ -1,3 +1,0 @@
-type Query {
-    getUsers: [User]
-}

--- a/src/guards/index.ts
+++ b/src/guards/index.ts
@@ -6,8 +6,9 @@ import { isAuthorized } from "./rules/index";
 export const permissions = shield(
     {
         Query: {
-            getUsers: isAuthorized,
-            getUser: isAuthorized
+            // User
+            user: isAuthorized,
+            users: isAuthorized
         },
         Mutation: {
             // Device


### PR DESCRIPTION
We will use a similar structure for queries like for mutations to keep also in the future the overview about the different queries.

Also, during this change, dropped "get" prefix of queries - all graphql queries are implicit getters, otherwhise they would be mutations.