### PR TITLE
Improve error message for environment variables

### DIFF
--- a/src/utils/envHandler.ts
+++ b/src/utils/envHandler.ts
@@ -17,7 +17,7 @@ class EnvHandler {
             return process.env[envVar] ?? defaultValue ?? "";
         }
         throw new Error(
-            "Please define a value for environment variable " + envVar
+            "Please define a default value for environment variable " + envVar
         );
     }
 


### PR DESCRIPTION
Make it more clear that the 'default' value is missing in case none
is given.