### PR TITLE
Add a simple api call to check if a user is currently logged in

### DIFF
--- a/src/graphql/resolvers/Queries/user/index.ts
+++ b/src/graphql/resolvers/Queries/user/index.ts
@@ -1,2 +1,3 @@
+export * from "./isLoggedin";
 export * from "./user";
 export * from "./users";

--- a/src/graphql/resolvers/Queries/user/isLoggedin.ts
+++ b/src/graphql/resolvers/Queries/user/isLoggedin.ts
@@ -1,0 +1,13 @@
+import { DidYouGetLoginData } from "../../../../utils/auth/model";
+
+export const isLoggedin = (
+    _parent: object,
+    _args: object,
+    context: { auth: DidYouGetLoginData }
+) => {
+    // If we already got this far, we can expect
+    // to be logged in successfully.
+    if (context.auth.userid) {
+        return { success: true };
+    }
+};

--- a/src/graphql/typeDefs/Queries/User.gql
+++ b/src/graphql/typeDefs/Queries/User.gql
@@ -1,4 +1,14 @@
 type Query {
+    """
+        Returns true if the user currently trying to connect is logged in.
+    """
+    isLoggedin: Status!
+    """
+        Returns either the user information for a given user id or the currently logged in user.
+    """
     user(id: ID): User
+    """
+        Returns all users in the database.
+    """
     users: [User]
 }

--- a/src/guards/index.ts
+++ b/src/guards/index.ts
@@ -11,6 +11,7 @@ export const permissions = shield(
             // ShoppingList
             shoppingLists: isAuthorized,
             // User
+            isLoggedin: isAuthorized,
             user: isAuthorized,
             users: isAuthorized
         },

--- a/tests/graphql/user.test.ts
+++ b/tests/graphql/user.test.ts
@@ -137,6 +137,17 @@ describe("an unauthorized user", () => {
         expect(response.body.errors[0].message).toBe("Not Authorised!");
     });
 
+    it("should get unauthorised message while checking login status", async () => {
+        const response = await runGraphQlQuery({
+            query: `query IsLoggedin {
+                isLoggedin {
+                    success
+                }
+            }`
+        });
+        expect(response.body.errors[0].message).toBe("Not Authorised!");
+    });
+
     it("should not be able to query all users", async () => {
         const response = await runGraphQlQuery({
             query: `query Users {
@@ -311,5 +322,17 @@ describe("an authorized user", () => {
         expect(loginResponse.body.data?.login.failureMessage).toBe(
             "Invalid user or password."
         );
+    });
+
+    it("should return success while checking login status", async () => {
+        const response = await runGraphQlQuery({
+            query: `query IsLoggedin {
+                isLoggedin {
+                    success
+                }
+            }`
+        });
+        expect(response.body.data?.errors).toBeUndefined();
+        expect(response.body.data?.isLoggedin.success).toBe(true);
     });
 });


### PR DESCRIPTION
This can be used e.g. by a client on startup as a cheap check if user tokens are still valid.